### PR TITLE
Enhance About page with interactive split image design

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -86,3 +86,34 @@ margin-top: 0;
       #surround:hover span[id="onhover"] {
         display: block;
       }
+/* Split image for About page */
+.about-split {
+  display: flex;
+  overflow: hidden;
+  border-radius: 8px;
+}
+
+.about-split-part {
+  width: 33.333%;
+  height: 300px;
+  object-fit: cover;
+  transition: transform 0.4s ease;
+  cursor: pointer;
+}
+
+.about-split-part.part-left {
+  object-position: left center;
+}
+
+.about-split-part.part-center {
+  object-position: center center;
+}
+
+.about-split-part.part-right {
+  object-position: right center;
+}
+
+.about-split-part:hover {
+  transform: scale(1.1);
+  box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+}

--- a/pages/resume.html
+++ b/pages/resume.html
@@ -42,8 +42,12 @@
 		<div class="section">
     	  <div class="row">
       
-    	    <h1 style="color:#333;">About  Me and Résumé</h1>
-			<img class="responsive-img" src="../img/about_me.jpg">
+            <h1 style="color:#333;">About  Me and Résumé</h1>
+            <div class="about-split">
+              <img src="https://images.unsplash.com/photo-1502685104226-ee32379fefbe?auto=format&fit=crop&w=900&q=80" alt="About me left" class="about-split-part part-left">
+              <img src="https://images.unsplash.com/photo-1502685104226-ee32379fefbe?auto=format&fit=crop&w=900&q=80" alt="About me center" class="about-split-part part-center">
+              <img src="https://images.unsplash.com/photo-1502685104226-ee32379fefbe?auto=format&fit=crop&w=900&q=80" alt="About me right" class="about-split-part part-right">
+            </div>
 		</div>
 		<div class="row">
 


### PR DESCRIPTION
## Summary
- Replace static photo on About page with a three-part interactive image using Unsplash portrait.
- Add custom CSS for split layout and hover zoom effect to create a more engaging design.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898d5e128e48328999a52d5f8a37d04