### PR TITLE
Refine About page with expanding tri-panel showcase

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -86,3 +86,54 @@ margin-top: 0;
       #surround:hover span[id="onhover"] {
         display: block;
       }
+/* Split image for About page */
+.about-split {
+  display: flex;
+  height: 400px;
+  overflow: hidden;
+  border-radius: 8px;
+}
+
+.about-split-part {
+  flex: 1;
+  background-size: cover;
+  background-position: center;
+  position: relative;
+  transition: flex 0.5s ease, filter 0.5s ease;
+  filter: grayscale(80%);
+  cursor: pointer;
+}
+
+.about-split-part:hover {
+  flex: 3;
+  filter: grayscale(0%);
+}
+
+.about-split-part .overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0,0,0,0.5);
+  color: #fff;
+  text-align: center;
+  padding: 1rem;
+  opacity: 0;
+  transition: opacity 0.5s ease;
+}
+
+.about-split-part:hover .overlay {
+  opacity: 1;
+}
+
+.about-split-part.part-one {
+  background-image: url("https://images.unsplash.com/photo-1503602642458-232111445657?auto=format&fit=crop&w=900&q=80");
+}
+
+.about-split-part.part-two {
+  background-image: url("https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=900&q=80");
+}
+
+.about-split-part.part-three {
+  background-image: url("https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=900&q=80");
+}

--- a/pages/resume.html
+++ b/pages/resume.html
@@ -42,8 +42,12 @@
 		<div class="section">
     	  <div class="row">
       
-    	    <h1 style="color:#333;">About  Me and Résumé</h1>
-			<img class="responsive-img" src="../img/about_me.jpg">
+            <h1 style="color:#333;">About  Me and Résumé</h1>
+            <div class="about-split">
+              <div class="about-split-part part-one"><div class="overlay">Architecture</div></div>
+              <div class="about-split-part part-two"><div class="overlay">Computation</div></div>
+              <div class="about-split-part part-three"><div class="overlay">Visualization</div></div>
+            </div>
 		</div>
 		<div class="row">
 


### PR DESCRIPTION
## Summary
- Rebuild About section with three-panel layout that expands on hover and reveals overlay text.
- Add new CSS for flex-based panels, grayscale-to-color transition, and individual background images.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898d5e128e48328999a52d5f8a37d04